### PR TITLE
Throw parsing exception when expression parsing throws error

### DIFF
--- a/src/main/java/de/neuland/pug4j/parser/Parser.java
+++ b/src/main/java/de/neuland/pug4j/parser/Parser.java
@@ -76,7 +76,12 @@ public class Parser {
             } else if(peek() instanceof TextHtml){
                 block.getNodes().addAll(parseTextHtml());
             } else {
-                Node expr = parseExpr();
+                Node expr = null;
+                try {
+                    expr = parseExpr();
+                } catch (Exception e) {
+                    throw error("new code", "Error parsing token", peek());
+                }
                 if (expr != null) {
                     if(expr instanceof BlockNode && !((BlockNode) expr).isYield()){
                         block.getNodes().addAll(expr.getNodes());

--- a/src/test/java/de/neuland/pug4j/parser/JadeParserTest.java
+++ b/src/test/java/de/neuland/pug4j/parser/JadeParserTest.java
@@ -53,4 +53,9 @@ public class JadeParserTest extends ParserTest {
         assertThat(blockNode.hasNodes(), equalTo(false));
     }
 
+    @Test
+    public void testBadExpression(){
+        loadInParser("bad_expression.jade");
+    }
+
 }

--- a/src/test/java/de/neuland/pug4j/parser/JadeParserTest.java
+++ b/src/test/java/de/neuland/pug4j/parser/JadeParserTest.java
@@ -1,14 +1,17 @@
 package de.neuland.pug4j.parser;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
+import de.neuland.pug4j.exceptions.PugParserException;
+import org.junit.Rule;
 import org.junit.Test;
 
 import de.neuland.pug4j.parser.node.BlockNode;
 import de.neuland.pug4j.parser.node.Node;
 import de.neuland.pug4j.parser.node.TagNode;
+import org.junit.rules.ExpectedException;
+import shadow.org.assertj.core.internal.bytebuddy.matcher.StringMatcher;
 
 public class JadeParserTest extends ParserTest {
 
@@ -53,8 +56,14 @@ public class JadeParserTest extends ParserTest {
         assertThat(blockNode.hasNodes(), equalTo(false));
     }
 
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
     @Test
-    public void testBadExpression(){
+    public void testBadExpression() {
+        exceptionRule.expect(PugParserException.class);
+        exceptionRule.expectMessage(containsString("parsing"));
+        exceptionRule.expectMessage(containsString("token"));
         loadInParser("bad_expression.jade");
     }
 

--- a/src/test/resources/parser/bad_expression.jade
+++ b/src/test/resources/parser/bad_expression.jade
@@ -1,2 +1,2 @@
 - variable = 0
-#{variable?'}
+h1 #{variable?'}

--- a/src/test/resources/parser/bad_expression.jade
+++ b/src/test/resources/parser/bad_expression.jade
@@ -1,0 +1,2 @@
+- variable = 0
+#{variable?'}


### PR DESCRIPTION
I discovered a type of invalid syntax which causes an out of bound exception in the parser, instead of a nice error with line number reference etc. This fixes it nicely enough for me (although character reference and line column number would be nicer).

Not sure how is should do the test though.

Closes #6 